### PR TITLE
Fix PITCHME.yaml typo, add missing slide delimiter.

### DIFF
--- a/PITCHME.md
+++ b/PITCHME.md
@@ -183,6 +183,8 @@ Note:
 Accessibility Insights for Web
 @snapend
 
+---
+
 - automated testing
 - manual testing assistance
 - reports

--- a/PITCHME.yaml
+++ b/PITCHME.yaml
@@ -18,7 +18,7 @@ theme-override: assets/css/PITCHME.css
 # https://gitpitch.com/docs/settings/logo
 #
 logo : assets/img/logo_globus.svg
-logo-postion : top-right
+logo-position : top-right
 
 #
 # Layout Setting


### PR DESCRIPTION
This PR fixes a number of small issues:

1.  A typo in the `PITCHME.yaml` was preventing *top-right* positioning for you logo.
1. And there was a missing slide delimiter on the penultimate slide which was causing content from two different slides to overlap on a single slide.
1. I'll follow up with an email to address some of the other issues that you raised.

Cheers, David.